### PR TITLE
FIX #71: switch case break for toJSObject & default return unknow type

### DIFF
--- a/android/src/io/jchat/android/Constant.java
+++ b/android/src/io/jchat/android/Constant.java
@@ -105,6 +105,7 @@ public class Constant {
     static final String PROGRESS = "progress";
     public static final String UNRECEIPT_COUNT = "unreceiptCount";
     public static final String IS_DESCEND = "isDescend";
+    public static final String UNKNOW = "unknow";
 
     /**
      * ChatRoom

--- a/android/src/io/jchat/android/utils/ResultUtils.java
+++ b/android/src/io/jchat/android/utils/ResultUtils.java
@@ -219,8 +219,9 @@ public class ResultUtils {
                             result.putString(Constant.EVENT_TYPE, "group_info_updated");
                             break;
                     }
+                    break;
                 default:
-                    return null;
+                    result.putString(Constant.TYPE, Constant.UNKNOW);
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
according to js which shows in example
https://github.com/jpush/jmessage-react-plugin/blob/c7e9843008d6dc4662afd4255e45d402b6327d67/example/app/routes/Chat/index.js#L184-L191
set the default to **unknow** type