### PR TITLE
fix: 缺少实现 `requiresMainQueueSetup`

### DIFF
--- a/ios/RCTJMessageModule/RCTJMessageModule.m
+++ b/ios/RCTJMessageModule/RCTJMessageModule.m
@@ -46,6 +46,11 @@ RCT_EXPORT_MODULE();
     return sharedInstance;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 - (id)init {
     self = [super init];
     [self initNotifications];


### PR DESCRIPTION
在 React Native 0.59.1 中 提示 warn: Module RCTJMessageModule requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.